### PR TITLE
Infer TypeFromDefinition from schema outputs

### DIFF
--- a/tests/useStandardSchema.test.tsx
+++ b/tests/useStandardSchema.test.tsx
@@ -19,11 +19,16 @@ function asyncEmail(
                 "~standard": {
                         version: 1,
                         vendor: "tests",
-                        async validate(value: string) {
+                        async validate(raw: unknown) {
+                                if (typeof raw !== "string") {
+                                        return { issues: [{ message }] }
+                                }
+
+                                const value = raw
                                 const delay = delays[value] ?? 0
                                 await new Promise((resolve) => setTimeout(resolve, delay))
 
-                                if (typeof value !== "string" || !/@/.test(value)) {
+                                if (!/@/.test(value)) {
                                         return { issues: [{ message }] }
                                 }
 


### PR DESCRIPTION
## Summary
- guard per-field validation from committing stale async results
- avoid committing state changes for superseded programmatic field updates
- add a regression test covering slow vs fast async email validation
- derive TypeFromDefinition from schema output types and add a type-level regression test

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d2d9b5472483329489ac260d8acc2a