### PR TITLE
Return boolean field flags and document FormData environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ type FieldProps = FieldDefinitionProps & {
 |------------------------------|-----------------------------------------------------------------------------|
 | `useStandardSchema(formDefinition)` | Initialize form state and validation with a form definition |
 | `getForm(onSubmit)`          | Returns event handlers for the form; submit handler only fires with valid data |
-| `getField(name)`             | Returns metadata for a given field (label, defaultValue, error, touched, dirty, ARIA ids) |
+| `getField(name)`             | Returns metadata for a given field (label, defaultValue, error, `touched`/`dirty` booleans, ARIA ids) |
 | `resetForm()`                | Resets all form state to initial defaults |
 | `isTouched(name?)`           | Returns `true/false` if form or field has been touched |
 | `isDirty(name?)`             | Returns `true/false` if form or field is dirty |
@@ -260,6 +260,8 @@ type FieldProps = FieldDefinitionProps & {
 <span style='color:red'>*</span>
 <strong>NOTE</strong>: This function does not validate the field.  It simply checks if it is currently valid.
 
+> **Environment note:** `toFormData` relies on the global [`FormData`](https://developer.mozilla.org/docs/Web/API/FormData) constructor. In SSR or other non-browser environments you may need to provide a polyfill (e.g. `undici` or `formdata-node`) or guard calls to `toFormData` to avoid runtime errors.
+
 ---
 
 ## Best Practices
@@ -268,6 +270,7 @@ type FieldProps = FieldDefinitionProps & {
 - **Error Display**: Use `getErrors()` for global errors and `field.error` for field-level errors.
 - **Performance**: Handlers and derived values (`getForm`, `getField`, `getErrors`) are memoized internally. You don’t need extra `useMemo` unless you’re doing heavy custom work.
 - **Reset Strategy**: Call `resetForm()` after successful submission to clear touched/dirty/errors and restore defaults.
+- **Boolean flags**: The `touched` and `dirty` values returned from `getField` are plain booleans, making it easy to toggle helper text, validation messaging, or styling without string comparisons.
 - **Nested Fields**: Use dot notation for nested keys (e.g. `"address.street1"`). TypeScript support ensures autocomplete for these paths.
 - **Accessibility**: Always wire `describedById` and `errorId` into your markup to keep your forms screen-reader friendly.
   - `getField` provides `describedById` and `errorId` for use with `aria-describedby` and/or `aria-errormessage`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,8 +163,8 @@ function useStandardSchema<T extends FormDefinition>(formDefinition: T) {
 				name: key,
 				defaultValue: data[key] ?? "",
 				error: errors[key] ?? "",
-				touched: touched[key] ? String(touched[key]) : "false",
-				dirty: dirty[key] ? String(dirty[key]) : "false",
+				touched: Boolean(touched[key]),
+				dirty: Boolean(dirty[key]),
 				describedById,
 				errorId,
 			}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,15 +9,15 @@ export type Flags = Record<string, boolean>
 export type Errors = Record<string, string>
 
 export interface FieldDefinition<Schema extends StandardSchemaV1 = StandardSchemaV1> {
-    label: string
-    description?: string
-    defaultValue?: string
-    validate: Schema
+	label: string
+	description?: string
+	defaultValue?: string
+	validate: Schema
 }
 
 /** A form schema tree: keys map to either fields or nested groups. */
 export type FormDefinition = {
-    [key: string]: FieldDefinition | FormDefinition
+	[key: string]: FieldDefinition | FormDefinition
 }
 
 /* =============================================================================
@@ -52,24 +52,24 @@ type Dec<D extends Depth> = DecMap[D]
  * Depth-limited so TS doesn’t infinitely expand on generics.
  */
 type DotFold<T, Prev extends string = "", Mode extends "paths" | "values" = "paths", D extends Depth = 10> = [
-    D,
+	D,
 ] extends [0]
-    ? never
-    : {
-        [K in keyof T]: T[K] extends FieldDefinition
-        ? Mode extends "paths"
-        ? `${Prev}${K & string}`
-        : { [P in `${Prev}${K & string}`]: FieldOutput<T[K]> }
-        : T[K] extends FormDefinition
-        ? DotFold<T[K], `${Prev}${K & string}.`, Mode, Dec<D>>
-        : never
-    }[keyof T]
+	? never
+	: {
+			[K in keyof T]: T[K] extends FieldDefinition
+				? Mode extends "paths"
+					? `${Prev}${K & string}`
+					: { [P in `${Prev}${K & string}`]: FieldOutput<T[K]> }
+				: T[K] extends FormDefinition
+					? DotFold<T[K], `${Prev}${K & string}.`, Mode, Dec<D>>
+					: never
+		}[keyof T]
 
 /** Public aliases */
 export type DotPaths<T, Prev extends string = "", D extends Depth = 10> = DotFold<T, Prev, "paths", D>
 
 type DotPathsToFieldOutputs<T, Prev extends string = "", D extends Depth = 10> = UnionToIntersection<
-    DotFold<T, Prev, "values", D>
+	DotFold<T, Prev, "values", D>
 >
 
 export type TypeFromDefinition<T extends FormDefinition> = Simplify<DotPathsToFieldOutputs<T>>
@@ -84,31 +84,31 @@ export type ErrorEntry = { name: string; error: string; label: string }
 
 /** ECMAScript WhiteSpace + LineTerminators + NBSP + BOM */
 type WhiteSpaceChar =
-    | " "
-    | "\t"
-    | "\n"
-    | "\r"
-    | "\v"
-    | "\f"
-    | "\u00A0"
-    | "\u1680"
-    | "\u2000"
-    | "\u2001"
-    | "\u2002"
-    | "\u2003"
-    | "\u2004"
-    | "\u2005"
-    | "\u2006"
-    | "\u2007"
-    | "\u2008"
-    | "\u2009"
-    | "\u200A"
-    | "\u2028"
-    | "\u2029"
-    | "\u202F"
-    | "\u205F"
-    | "\u3000"
-    | "\uFEFF"
+	| " "
+	| "\t"
+	| "\n"
+	| "\r"
+	| "\v"
+	| "\f"
+	| "\u00A0"
+	| "\u1680"
+	| "\u2000"
+	| "\u2001"
+	| "\u2002"
+	| "\u2003"
+	| "\u2004"
+	| "\u2005"
+	| "\u2006"
+	| "\u2007"
+	| "\u2008"
+	| "\u2009"
+	| "\u200A"
+	| "\u2028"
+	| "\u2029"
+	| "\u202F"
+	| "\u205F"
+	| "\u3000"
+	| "\uFEFF"
 
 /**
  * A single segment (between dots) is valid iff:
@@ -118,21 +118,21 @@ type WhiteSpaceChar =
  *  All other Unicode code points (incl. hyphens, emoji, etc.) are allowed.
  */
 type _IsValidSegment<S extends string> = S extends ""
-    ? false
-    : S extends `${string}${WhiteSpaceChar}${string}`
-    ? false
-    : S extends `${string}.${string}`
-    ? false
-    : true
+	? false
+	: S extends `${string}${WhiteSpaceChar}${string}`
+		? false
+		: S extends `${string}.${string}`
+			? false
+			: true
 
 /** Full key: one or more valid segments separated by dots. */
 export type FormPathKey<S extends string> = S extends `${infer Head}.${infer Tail}`
-    ? _IsValidSegment<Head> extends true
-    ? FormPathKey<Tail>
-    : never
-    : _IsValidSegment<S> extends true
-    ? S
-    : never
+	? _IsValidSegment<Head> extends true
+		? FormPathKey<Tail>
+		: never
+	: _IsValidSegment<S> extends true
+		? S
+		: never
 
 /** Shape-only path type for APIs not tied to a specific schema. */
 export type AnyFormPathKey = FormPathKey<string>
@@ -144,15 +144,15 @@ export type AnyFormPathKey = FormPathKey<string>
  * - Recurse into nested FormDefinition branches
  */
 type _HasInvalidKeys<T> = {
-    [K in keyof T]: K extends string
-    ? string extends K
-    ? false // skip index signature
-    : FormPathKey<K> extends never
-    ? true
-    : T[K] extends FormDefinition
-    ? _HasInvalidKeys<T[K]>
-    : false
-    : false
+	[K in keyof T]: K extends string
+		? string extends K
+			? false // skip index signature
+			: FormPathKey<K> extends never
+				? true
+				: T[K] extends FormDefinition
+					? _HasInvalidKeys<T[K]>
+					: false
+		: false
 }[keyof T]
 
 /**
@@ -161,12 +161,14 @@ type _HasInvalidKeys<T> = {
  * - Otherwise, preserve the exact inferred shape of `T` (recursing only to check)
  */
 export type AssertValidFormKeysDeep<T extends FormDefinition> = true extends _HasInvalidKeys<T>
-    ? never
-    : { [K in keyof T]: T[K] extends FormDefinition ? AssertValidFormKeysDeep<T[K]> : T[K] }
+	? never
+	: { [K in keyof T]: T[K] extends FormDefinition ? AssertValidFormKeysDeep<T[K]> : T[K] }
 
 export interface FieldDefintionProps extends FieldDefinition {
-    name: string
-    error: string
-    errorId: string
-    describedById: string
+	name: string
+	error: string
+	errorId: string
+	describedById: string
+	touched: boolean
+	dirty: boolean
 }

--- a/tests/useStandardSchema.test.tsx
+++ b/tests/useStandardSchema.test.tsx
@@ -219,7 +219,7 @@ describe("useStandardSchema", () => {
 		})
 
 		await act(async () => {
-			await wait(delays.slow + 10)
+			await sleep(delays.slow + 10)
 		})
 
 		expect(screen.getByTestId("email-error")).toHaveTextContent("")


### PR DESCRIPTION
## Summary
- return `touched` and `dirty` from `getField` as booleans to better align with JSX conditionals
- expose the new boolean shape in `FieldDefintionProps`
- document the boolean behavior in the README and warn that `toFormData` requires a `FormData` global when running outside the browser
- run the Biome formatter so the updated files follow the existing code style

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d59296e6908332a8ef59f5c2722709