### PR TITLE
Fix harness schema typing

### DIFF
--- a/tests/test-harness.tsx
+++ b/tests/test-harness.tsx
@@ -1,30 +1,33 @@
 import React, { useImperativeHandle } from "react"
 import { useStandardSchema } from "../src"
-import type { DotPaths, FormDefinition, TypeFromDefinition } from "../src"
+import type { DotPaths, FieldDefinition, FormDefinition, TypeFromDefinition } from "../src"
 
-type EnsurePath<TSchema extends FormDefinition, TPath extends string> = TPath extends DotPaths<TSchema>
-        ? TSchema
-        : never
+type RequiredHarnessFields = {
+        user: ({
+                name: FieldDefinition
+        } & FormDefinition) & {
+                contact: ({
+                        email: FieldDefinition
+                } & FormDefinition)
+        }
+}
 
-export type HarnessSchema<TSchema extends FormDefinition = FormDefinition> = EnsurePath<
-        EnsurePath<TSchema, "user.name">,
-        "user.contact.email"
->
+export type HarnessSchema = FormDefinition & RequiredHarnessFields
 
-type PathFor<TSchema extends FormDefinition, TPath extends string> = TPath extends DotPaths<TSchema>
+type PathFor<TSchema extends HarnessSchema, TPath extends string> = TPath extends DotPaths<TSchema>
         ? TPath
         : never
 
-export type HarnessApi<TSchema extends FormDefinition = FormDefinition> = ReturnType<
+export type HarnessApi<TSchema extends HarnessSchema = HarnessSchema> = ReturnType<
         typeof useStandardSchema<TSchema>
 >
 
-export interface HarnessProps<TSchema extends FormDefinition> {
-        schema: HarnessSchema<TSchema>
+export interface HarnessProps<TSchema extends HarnessSchema> {
+        schema: TSchema
         onSubmit: (data: TypeFromDefinition<TSchema>) => void
 }
 
-export const Harness = React.forwardRef(function Harness<TSchema extends FormDefinition>(
+export const Harness = React.forwardRef(function Harness<TSchema extends HarnessSchema>(
         { schema, onSubmit }: HarnessProps<TSchema>,
         ref: React.ForwardedRef<HarnessApi<TSchema>>,
 ) {

--- a/tests/useStandardSchema.test.tsx
+++ b/tests/useStandardSchema.test.tsx
@@ -3,14 +3,14 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import React from "react"
 import { describe, expect, expectTypeOf, it, vi } from "vitest"
-import { defineForm, type TypeFromDefinition } from "../src"
+import { defineForm, type FormDefinition, type TypeFromDefinition } from "../src"
 import { Harness, type HarnessApi, type HarnessSchema } from "./test-harness"
 import { email, string } from "./test-validation-lib"
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-function renderHarnessWithApi<TSchema extends HarnessSchema>(
-        schema: TSchema,
+function renderHarnessWithApi<TSchema extends FormDefinition>(
+        schema: HarnessSchema<TSchema>,
         onSubmit: (data: TypeFromDefinition<TSchema>) => void,
 ) {
         const ref = React.createRef<HarnessApi<TSchema>>()

--- a/tests/useStandardSchema.test.tsx
+++ b/tests/useStandardSchema.test.tsx
@@ -3,14 +3,14 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import React from "react"
 import { describe, expect, expectTypeOf, it, vi } from "vitest"
-import { defineForm, type FormDefinition, type TypeFromDefinition } from "../src"
+import { defineForm, type TypeFromDefinition } from "../src"
 import { Harness, type HarnessApi, type HarnessSchema } from "./test-harness"
 import { email, string } from "./test-validation-lib"
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-function renderHarnessWithApi<TSchema extends FormDefinition>(
-        schema: HarnessSchema<TSchema>,
+function renderHarnessWithApi<TSchema extends HarnessSchema>(
+        schema: TSchema,
         onSubmit: (data: TypeFromDefinition<TSchema>) => void,
 ) {
         const ref = React.createRef<HarnessApi<TSchema>>()


### PR DESCRIPTION
## Summary
- constrain the React test harness schema to require the name and email fields so hook dot-paths stay type-safe
- update the harness render helper and invalid key test to use the refined schema typing while asserting runtime guards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d6fb94b824833292f433710dd8f091