### PR TITLE
feat: add helper functions for dirty/touched state

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ type FieldProps = FieldDefinitionProps & {
 | `getForm(onSubmit)`          | Returns event handlers for the form; submit handler only fires with valid data |
 | `getField(name)`             | Returns metadata for a given field (label, defaultValue, error, touched, dirty, ARIA ids) |
 | `resetForm()`                | Resets all form state to initial defaults |
-| `touched`                    | Read-only frozen object of touched fields |
-| `dirty`                      | Read-only frozen object of dirty fields |
+| `isTouched(name?)`           | Returns whether a field (or any field when omitted) has been touched |
+| `isDirty(name?)`             | Returns whether a field (or any field when omitted) has been modified |
 | `toFormData(data)`           | Helper to convert values to `FormData` |
 | `getErrors(name?)`                | Returns an array of `{ name, error, label }` for field or form |
 | `validate(name?)`            | Validates either the entire form or a single field |

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,19 +199,40 @@ function useStandardSchema<T extends FormDefinition>(formDefinition: T) {
 		[formDefinitionKeys, errors, flatFormDefinition],
 	)
 
-	const touchedFrozen = useMemo(() => Object.freeze({ ...touched }), [touched])
-	const dirtyFrozen = useMemo(() => Object.freeze({ ...dirty }), [dirty])
+        const isTouched = useCallback(
+                (name?: FieldKey) => {
+                        if (name) {
+                                const key = name as string
+                                return Boolean(touched[key])
+                        }
 
-	return {
-		resetForm,
-		getForm,
-		getField,
-		getErrors,
-		validate,
-		__dangerouslySetField: setField,
-		touched: touchedFrozen,
-		dirty: dirtyFrozen,
-	}
+                        return Object.values(touched).some(Boolean)
+                },
+                [touched],
+        )
+
+        const isDirty = useCallback(
+                (name?: FieldKey) => {
+                        if (name) {
+                                const key = name as string
+                                return Boolean(dirty[key])
+                        }
+
+                        return Object.values(dirty).some(Boolean)
+                },
+                [dirty],
+        )
+
+        return {
+                resetForm,
+                getForm,
+                getField,
+                getErrors,
+                validate,
+                __dangerouslySetField: setField,
+                isTouched,
+                isDirty,
+        }
 }
 
 export { useStandardSchema, defineForm, toFormData }

--- a/tests/useStandardSchema.test.tsx
+++ b/tests/useStandardSchema.test.tsx
@@ -75,6 +75,53 @@ describe("useStandardSchema", () => {
 		expect(emailInput).toHaveAttribute("aria-invalid", "true")
 	})
 
+	it("exposes isTouched/isDirty helpers for form-level and field checks", async () => {
+		let api: HarnessApi
+		const onSubmit = vi.fn()
+		const user = userEvent.setup()
+
+		render(
+			<Harness
+				schema={schema}
+				onSubmit={onSubmit}
+				onApi={(x) => {
+					api = x
+				}}
+			/>,
+		)
+
+		const emailInput = screen.getByTestId("email") as HTMLInputElement
+		const resetButton = screen.getByText("Reset")
+
+		expect(api!.isTouched()).toBe(false)
+		expect(api!.isTouched("user.contact.email")).toBe(false)
+		expect(api!.isDirty()).toBe(false)
+		expect(api!.isDirty("user.contact.email")).toBe(false)
+
+		await user.click(emailInput)
+		await user.tab()
+
+		expect(api!.isTouched()).toBe(true)
+		expect(api!.isTouched("user.contact.email")).toBe(true)
+		expect(api!.isTouched("user.name")).toBe(false)
+		expect(api!.isDirty()).toBe(false)
+		expect(api!.isDirty("user.contact.email")).toBe(false)
+
+		await user.click(emailInput)
+		await user.clear(emailInput)
+		await user.type(emailInput, "new@example.com")
+		await user.tab()
+
+		expect(api!.isDirty()).toBe(true)
+		expect(api!.isDirty("user.contact.email")).toBe(true)
+		expect(api!.isDirty("user.name")).toBe(false)
+
+		await user.click(resetButton)
+
+		expect(api!.isTouched()).toBe(false)
+		expect(api!.isDirty()).toBe(false)
+	})
+
 	it("onFocus clears error for that field", async () => {
 		const onSubmit = vi.fn()
 		const user = userEvent.setup()


### PR DESCRIPTION
## Summary
- replace the exposed touched/dirty objects with isTouched/isDirty helper functions that support optional field names
- add coverage for the new helpers and document the API changes in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68daa00c5e348332a3b64cac60e4e308