### PR TITLE
Refine d.ts type assertions to use existing schema types

### DIFF
--- a/tests/types.test-d.ts
+++ b/tests/types.test-d.ts
@@ -1,24 +1,27 @@
 // This file is a TypeScript-only (d.ts) style assertion to ensure exported types match expected shapes.
 // It's not executed at runtime; it helps catch regressions in the public API surface.
 
-import { UseStandardSchemaReturn, useStandardSchema } from "../src"
-import { defineForm } from "../src/helpers"
-import type { TypeFromDefinition } from "../src/types"
+import type { StandardSchemaV1 } from "@standard-schema/spec"
+import { useStandardSchema } from "../src"
+import type { AssertValidFormKeysDeep, FormDefinition, UseStandardSchemaReturn } from "../src/types"
 
-// Use a minimal StandardSchemaV1-shaped stub for the validator in a type-only way.
-const form = defineForm({
-	foo: {
-		label: "Foo",
-		defaultValue: "",
-		validate: undefined as unknown as import("../src/types").FieldDefinition["validate"],
-	},
-})
+type Validator = StandardSchemaV1<string>
 
-type Form = typeof form
+type TestFormDefinition = AssertValidFormKeysDeep<{
+        foo: {
+                label: "Foo"
+                defaultValue: ""
+                validate: Validator
+        }
+}>
 
-type Hook = ReturnType<typeof useStandardSchema<Form>>
+type Hook = typeof useStandardSchema extends <T extends FormDefinition>(
+        formDefinition: TestFormDefinition,
+) => infer R
+        ? R
+        : never
 
-// Assert Hook matches exported UseStandardSchemaReturn<Form>
-type _Assert = Hook extends UseStandardSchemaReturn<Form> ? true : never
+// Assert Hook matches exported UseStandardSchemaReturn<TestFormDefinition>
+type _Assert = Hook extends UseStandardSchemaReturn<TestFormDefinition> ? true : never
 
 export {}


### PR DESCRIPTION
## Summary
- update the type assertion test to use StandardSchemaV1 and AssertValidFormKeysDeep for the validator and form definition
- infer the hook return type via the useStandardSchema signature without relying on ReturnType

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dbfa526a18833293c676d83f49d45e