### PR TITLE
Handle validator exceptions gracefully

### DIFF
--- a/tests/test-validation-lib.ts
+++ b/tests/test-validation-lib.ts
@@ -36,3 +36,20 @@ export function email(message: string = "Invalid email"): StringSchema {
 		},
 	}
 }
+
+export function throwing(message: string = "Boom!"): StringSchema {
+	return {
+		type: "string",
+		message,
+		"~standard": {
+			version: 1,
+			vendor: "tests",
+			async validate(value) {
+				if (typeof value !== "string" || value.trim().length === 0) {
+					throw new Error(message)
+				}
+				return { value }
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- prevent thrown validator errors from surfacing to consumers by translating them into messages in `useStandardSchema`
- add a throwing validator helper for tests and cover the new error handling behavior

## Testing
- npm test
- npm run check:strict
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e3d567bba88332947f434f9df8a266