### PR TITLE
Simplify validation helpers and schema flattening

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -68,8 +68,6 @@ export type TypeFromDefinition<T extends FormDefinition> = {
 	[K in keyof DotPathsToValues<T>]: DotPathsToValues<T>[K]
 }
 
-export type FieldMapper<T> = (fieldDef: FieldDefinition, path: string) => T
-export type RecurseFn<T> = (subSchema: FormDefinition, path: string) => Record<string, T>
 export type ErrorEntry = { name: string; error: string; label: string }
 
 /* =============================================================================


### PR DESCRIPTION
## Summary
- simplify the schema flattening helpers by removing the generic mapper plumbing while preserving behavior
- centralize validator extraction and message handling to streamline validation logic in the hook

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e3e24e303c8332b65fd61340bc3c51